### PR TITLE
Proof of concept to push running Jupyter notebooks and dependencies to git

### DIFF
--- a/jupyter2repo/.gitignore
+++ b/jupyter2repo/.gitignore
@@ -1,0 +1,121 @@
+*.bundle.*
+lib/
+node_modules/
+*.log
+.eslintcache
+.stylelintcache
+*.egg-info/
+.ipynb_checkpoints
+*.tsbuildinfo
+jupyter2repo/labextension
+# Version file is handled by hatchling
+jupyter2repo/_version.py
+
+# Created by https://www.gitignore.io/api/python
+# Edit at https://www.gitignore.io/?templates=python
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage/
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# Mr Developer
+.mr.developer.cfg
+.project
+.pydevproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# End of https://www.gitignore.io/api/python
+
+# OSX files
+.DS_Store
+
+# Yarn cache
+.yarn/

--- a/jupyter2repo/CHANGELOG.md
+++ b/jupyter2repo/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+<!-- <START NEW CHANGELOG ENTRY> -->
+
+<!-- <END NEW CHANGELOG ENTRY> -->

--- a/jupyter2repo/README.md
+++ b/jupyter2repo/README.md
@@ -1,0 +1,77 @@
+# jupyter2repo
+
+[![Github Actions Status](/workflows/Build/badge.svg)](/actions/workflows/build.yml)
+
+A JupyterLab extension.
+
+## Requirements
+
+- JupyterLab >= 4.0.0
+
+## Install
+
+To install the extension, execute:
+
+```bash
+pip install jupyter2repo
+```
+
+## Uninstall
+
+To remove the extension, execute:
+
+```bash
+pip uninstall jupyter2repo
+```
+
+## Contributing
+
+### Development install
+
+Note: You will need NodeJS to build the extension package.
+
+The `jlpm` command is JupyterLab's pinned version of
+[yarn](https://yarnpkg.com/) that is installed with JupyterLab. You may use
+`yarn` or `npm` in lieu of `jlpm` below.
+
+```bash
+# Clone the repo to your local environment
+# Change directory to the jupyter2repo directory
+# Install package in development mode
+pip install -e "."
+# Link your development version of the extension with JupyterLab
+jupyter labextension develop . --overwrite
+# Rebuild extension Typescript source after making changes
+jlpm build
+```
+
+You can watch the source directory and run JupyterLab at the same time in different terminals to watch for changes in the extension's source and automatically rebuild the extension.
+
+```bash
+# Watch the source directory in one terminal, automatically rebuilding when needed
+jlpm watch
+# Run JupyterLab in another terminal
+jupyter lab
+```
+
+With the watch command running, every saved change will immediately be built locally and available in your running JupyterLab. Refresh JupyterLab to load the change in your browser (you may need to wait several seconds for the extension to be rebuilt).
+
+By default, the `jlpm build` command generates the source maps for this extension to make it easier to debug using the browser dev tools. To also generate source maps for the JupyterLab core extensions, you can run the following command:
+
+```bash
+jupyter lab build --minimize=False
+```
+
+### Development uninstall
+
+```bash
+pip uninstall jupyter2repo
+```
+
+In development mode, you will also need to remove the symlink created by `jupyter labextension develop`
+command. To find its location, you can run `jupyter labextension list` to figure out where the `labextensions`
+folder is located. Then you can remove the symlink named `jupyter2repo` within that folder.
+
+### Packaging the extension
+
+See [RELEASE](RELEASE.md)

--- a/jupyter2repo/RELEASE.md
+++ b/jupyter2repo/RELEASE.md
@@ -1,0 +1,80 @@
+# Making a new release of jupyter2repo
+
+The extension can be published to `PyPI` and `npm` manually or using the [Jupyter Releaser](https://github.com/jupyter-server/jupyter_releaser).
+
+## Manual release
+
+### Python package
+
+This extension can be distributed as Python packages. All of the Python
+packaging instructions are in the `pyproject.toml` file to wrap your extension in a
+Python package. Before generating a package, you first need to install some tools:
+
+```bash
+pip install build twine hatch
+```
+
+Bump the version using `hatch`. By default this will create a tag.
+See the docs on [hatch-nodejs-version](https://github.com/agoose77/hatch-nodejs-version#semver) for details.
+
+```bash
+hatch version <new-version>
+```
+
+Make sure to clean up all the development files before building the package:
+
+```bash
+jlpm clean:all
+```
+
+You could also clean up the local git repository:
+
+```bash
+git clean -dfX
+```
+
+To create a Python source package (`.tar.gz`) and the binary package (`.whl`) in the `dist/` directory, do:
+
+```bash
+python -m build
+```
+
+> `python setup.py sdist bdist_wheel` is deprecated and will not work for this package.
+
+Then to upload the package to PyPI, do:
+
+```bash
+twine upload dist/*
+```
+
+### NPM package
+
+To publish the frontend part of the extension as a NPM package, do:
+
+```bash
+npm login
+npm publish --access public
+```
+
+## Automated releases with the Jupyter Releaser
+
+The extension repository should already be compatible with the Jupyter Releaser. But
+the GitHub repository and the package managers need to be properly set up. Please
+follow the instructions of the Jupyter Releaser [checklist](https://jupyter-releaser.readthedocs.io/en/latest/how_to_guides/convert_repo_from_repo.html).
+
+Here is a summary of the steps to cut a new release:
+
+- Go to the Actions panel
+- Run the "Step 1: Prep Release" workflow
+- Check the draft changelog
+- Run the "Step 2: Publish Release" workflow
+
+> [!NOTE]
+> Check out the [workflow documentation](https://jupyter-releaser.readthedocs.io/en/latest/get_started/making_release_from_repo.html)
+> for more information.
+
+## Publishing to `conda-forge`
+
+If the package is not on conda forge yet, check the documentation to learn how to add it: https://conda-forge.org/docs/maintainer/adding_pkgs.html
+
+Otherwise a bot should pick up the new version publish to PyPI, and open a new PR on the feedstock repository automatically.

--- a/jupyter2repo/install.json
+++ b/jupyter2repo/install.json
@@ -1,0 +1,5 @@
+{
+  "packageManager": "python",
+  "packageName": "jupyter2repo",
+  "uninstallInstructions": "Use your Python package manager (pip, conda, etc.) to uninstall the package jupyter2repo"
+}

--- a/jupyter2repo/jupyter2repo/__init__.py
+++ b/jupyter2repo/jupyter2repo/__init__.py
@@ -1,0 +1,16 @@
+try:
+    from ._version import __version__
+except ImportError:
+    # Fallback when using the package in dev mode without installing
+    # in editable mode with pip. It is highly recommended to install
+    # the package from a stable release or in editable mode: https://pip.pypa.io/en/stable/topics/local-project-installs/#editable-installs
+    import warnings
+    warnings.warn("Importing 'jupyter2repo' outside a proper installation.")
+    __version__ = "dev"
+
+
+def _jupyter_labextension_paths():
+    return [{
+        "src": "labextension",
+        "dest": "jupyter2repo"
+    }]

--- a/jupyter2repo/package.json
+++ b/jupyter2repo/package.json
@@ -1,0 +1,194 @@
+{
+    "name": "jupyter2repo",
+    "version": "0.1.0",
+    "description": "A JupyterLab extension.",
+    "keywords": [
+        "jupyter",
+        "jupyterlab",
+        "jupyterlab-extension"
+    ],
+    "homepage": "",
+    "bugs": {
+        "url": "/issues"
+    },
+    "license": "BSD-3-Clause",
+    "author": {
+        "name": "Dan Subak",
+        "email": "dansubak@mit.edu"
+    },
+    "files": [
+        "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
+        "style/**/*.{css,js,eot,gif,html,jpg,json,png,svg,woff2,ttf}",
+        "src/**/*.{ts,tsx}"
+    ],
+    "main": "lib/index.js",
+    "types": "lib/index.d.ts",
+    "style": "style/index.css",
+    "repository": {
+        "type": "git",
+        "url": ".git"
+    },
+    "scripts": {
+        "build": "jlpm build:lib && jlpm build:labextension:dev",
+        "build:prod": "jlpm clean && jlpm build:lib:prod && jlpm build:labextension",
+        "build:labextension": "jupyter labextension build .",
+        "build:labextension:dev": "jupyter labextension build --development True .",
+        "build:lib": "tsc --sourceMap",
+        "build:lib:prod": "tsc",
+        "clean": "jlpm clean:lib",
+        "clean:lib": "rimraf lib tsconfig.tsbuildinfo",
+        "clean:lintcache": "rimraf .eslintcache .stylelintcache",
+        "clean:labextension": "rimraf jupyter2repo/labextension jupyter2repo/_version.py",
+        "clean:all": "jlpm clean:lib && jlpm clean:labextension && jlpm clean:lintcache",
+        "eslint": "jlpm eslint:check --fix",
+        "eslint:check": "eslint . --cache --ext .ts,.tsx",
+        "install:extension": "jlpm build",
+        "lint": "jlpm stylelint && jlpm prettier && jlpm eslint",
+        "lint:check": "jlpm stylelint:check && jlpm prettier:check && jlpm eslint:check",
+        "prettier": "jlpm prettier:base --write --list-different",
+        "prettier:base": "prettier \"**/*{.ts,.tsx,.js,.jsx,.css,.json,.md}\"",
+        "prettier:check": "jlpm prettier:base --check",
+        "stylelint": "jlpm stylelint:check --fix",
+        "stylelint:check": "stylelint --cache \"style/**/*.css\"",
+        "watch": "run-p watch:src watch:labextension",
+        "watch:src": "tsc -w --sourceMap",
+        "watch:labextension": "jupyter labextension watch ."
+    },
+    "dependencies": {
+        "@jupyterlab/application": "^4.0.0",
+        "@jupyterlab/codeeditor": "^4.0.0",
+        "@jupyterlab/completer": "^4.0.0",
+        "@jupyterlab/notebook": "^4.0.0",
+        "@jupyterlab/settingregistry": "^4.0.0"
+    },
+    "devDependencies": {
+        "@jupyterlab/builder": "^4.0.0",
+        "@jupyterlab/testutils": "^4.0.0",
+        "@types/jest": "^29.2.0",
+        "@types/json-schema": "^7.0.11",
+        "@types/react": "^18.0.26",
+        "@types/react-addons-linked-state-mixin": "^0.14.22",
+        "@typescript-eslint/eslint-plugin": "^6.1.0",
+        "@typescript-eslint/parser": "^6.1.0",
+        "css-loader": "^6.7.1",
+        "eslint": "^8.36.0",
+        "eslint-config-prettier": "^8.8.0",
+        "eslint-plugin-prettier": "^5.0.0",
+        "jest": "^29.2.0",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^3.0.0",
+        "rimraf": "^5.0.1",
+        "source-map-loader": "^1.0.2",
+        "style-loader": "^3.3.1",
+        "stylelint": "^15.10.1",
+        "stylelint-config-recommended": "^13.0.0",
+        "stylelint-config-standard": "^34.0.0",
+        "stylelint-csstree-validator": "^3.0.0",
+        "stylelint-prettier": "^4.0.0",
+        "typescript": "~5.2.0",
+        "yjs": "^13.5.0"
+    },
+    "sideEffects": [
+        "style/*.css",
+        "style/index.js"
+    ],
+    "styleModule": "style/index.js",
+    "publishConfig": {
+        "access": "public"
+    },
+    "jupyterlab": {
+        "extension": true,
+        "outputDir": "jupyter2repo/labextension"
+    },
+    "eslintIgnore": [
+        "node_modules",
+        "dist",
+        "coverage",
+        "**/*.d.ts"
+    ],
+    "eslintConfig": {
+        "extends": [
+            "eslint:recommended",
+            "plugin:@typescript-eslint/eslint-recommended",
+            "plugin:@typescript-eslint/recommended",
+            "plugin:prettier/recommended"
+        ],
+        "parser": "@typescript-eslint/parser",
+        "parserOptions": {
+            "project": "tsconfig.json",
+            "sourceType": "module"
+        },
+        "plugins": [
+            "@typescript-eslint"
+        ],
+        "rules": {
+            "@typescript-eslint/naming-convention": [
+                "error",
+                {
+                    "selector": "interface",
+                    "format": [
+                        "PascalCase"
+                    ],
+                    "custom": {
+                        "regex": "^I[A-Z]",
+                        "match": true
+                    }
+                }
+            ],
+            "@typescript-eslint/no-unused-vars": [
+                "warn",
+                {
+                    "args": "none"
+                }
+            ],
+            "@typescript-eslint/no-explicit-any": "off",
+            "@typescript-eslint/no-namespace": "off",
+            "@typescript-eslint/no-use-before-define": "off",
+            "@typescript-eslint/quotes": [
+                "error",
+                "single",
+                {
+                    "avoidEscape": true,
+                    "allowTemplateLiterals": false
+                }
+            ],
+            "curly": [
+                "error",
+                "all"
+            ],
+            "eqeqeq": "error",
+            "prefer-arrow-callback": "error"
+        }
+    },
+    "prettier": {
+        "singleQuote": true,
+        "trailingComma": "none",
+        "arrowParens": "avoid",
+        "endOfLine": "auto",
+        "overrides": [
+            {
+                "files": "package.json",
+                "options": {
+                    "tabWidth": 4
+                }
+            }
+        ]
+    },
+    "stylelint": {
+        "extends": [
+            "stylelint-config-recommended",
+            "stylelint-config-standard",
+            "stylelint-prettier/recommended"
+        ],
+        "plugins": [
+            "stylelint-csstree-validator"
+        ],
+        "rules": {
+            "csstree/validator": true,
+            "property-no-vendor-prefix": null,
+            "selector-class-pattern": "^([a-z][A-z\\d]*)(-[A-z\\d]+)*$",
+            "selector-no-vendor-prefix": null,
+            "value-no-vendor-prefix": null
+        }
+    }
+}

--- a/jupyter2repo/package.json
+++ b/jupyter2repo/package.json
@@ -19,7 +19,8 @@
     "files": [
         "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
         "style/**/*.{css,js,eot,gif,html,jpg,json,png,svg,woff2,ttf}",
-        "src/**/*.{ts,tsx}"
+        "src/**/*.{ts,tsx}",
+        "schema/*.json"
     ],
     "main": "lib/index.js",
     "types": "lib/index.d.ts",
@@ -98,7 +99,8 @@
     },
     "jupyterlab": {
         "extension": true,
-        "outputDir": "jupyter2repo/labextension"
+        "outputDir": "jupyter2repo/labextension",
+        "schemaDir": "schema"
     },
     "eslintIgnore": [
         "node_modules",

--- a/jupyter2repo/pyproject.toml
+++ b/jupyter2repo/pyproject.toml
@@ -1,0 +1,77 @@
+[build-system]
+requires = ["hatchling>=1.5.0", "jupyterlab>=4.0.0,<5", "hatch-nodejs-version>=0.3.2"]
+build-backend = "hatchling.build"
+
+[project]
+name = "jupyter2repo"
+readme = "README.md"
+license = { file = "LICENSE" }
+requires-python = ">=3.9"
+classifiers = [
+    "Framework :: Jupyter",
+    "Framework :: Jupyter :: JupyterLab",
+    "Framework :: Jupyter :: JupyterLab :: 4",
+    "Framework :: Jupyter :: JupyterLab :: Extensions",
+    "Framework :: Jupyter :: JupyterLab :: Extensions :: Prebuilt",
+    "License :: OSI Approved :: BSD License",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+]
+dependencies = [
+]
+dynamic = ["version", "description", "authors", "urls", "keywords"]
+
+[tool.hatch.version]
+source = "nodejs"
+
+[tool.hatch.metadata.hooks.nodejs]
+fields = ["description", "authors", "urls", "keywords"]
+
+[tool.hatch.build.targets.sdist]
+artifacts = ["jupyter2repo/labextension"]
+exclude = [".github", "binder"]
+
+[tool.hatch.build.targets.wheel.shared-data]
+"jupyter2repo/labextension" = "share/jupyter/labextensions/jupyter2repo"
+"install.json" = "share/jupyter/labextensions/jupyter2repo/install.json"
+
+[tool.hatch.build.hooks.version]
+path = "jupyter2repo/_version.py"
+
+[tool.hatch.build.hooks.jupyter-builder]
+dependencies = ["hatch-jupyter-builder>=0.5"]
+build-function = "hatch_jupyter_builder.npm_builder"
+ensured-targets = [
+    "jupyter2repo/labextension/static/style.js",
+    "jupyter2repo/labextension/package.json",
+]
+skip-if-exists = ["jupyter2repo/labextension/static/style.js"]
+
+[tool.hatch.build.hooks.jupyter-builder.build-kwargs]
+build_cmd = "build:prod"
+npm = ["jlpm"]
+
+[tool.hatch.build.hooks.jupyter-builder.editable-build-kwargs]
+build_cmd = "install:extension"
+npm = ["jlpm"]
+source_dir = "src"
+build_dir = "jupyter2repo/labextension"
+
+[tool.jupyter-releaser.options]
+version_cmd = "hatch version"
+
+[tool.jupyter-releaser.hooks]
+before-build-npm = [
+    "python -m pip install 'jupyterlab>=4.0.0,<5'",
+    "jlpm",
+    "jlpm build:prod"
+]
+before-build-python = ["jlpm clean:all"]
+
+[tool.check-wheel-contents]
+ignore = ["W002"]

--- a/jupyter2repo/schema/plugin.json
+++ b/jupyter2repo/schema/plugin.json
@@ -1,0 +1,22 @@
+{
+  "jupyter.lab.setting-icon": "ui-components:save",
+  "jupyter.lab.setting-icon-label": "Jupyter2Repo",
+  "title": "Jupyter2Repo Settings",
+  "description": "Settings for the Jupyter2Repo extension",
+  "type": "object",
+  "properties": {
+    "GH_APP_ID": {
+      "type": ["string"],
+      "title": "GitHub App ID",
+      "readOnly": true,
+      "default": "test"
+    },
+    "GH_APP_URL": {
+      "type": ["string"],
+      "title": "GitHub App URL",
+      "readOnly": true,
+      "default": "test2"
+    }
+  },
+  "additionalProperties": false
+}

--- a/jupyter2repo/setup.py
+++ b/jupyter2repo/setup.py
@@ -1,0 +1,1 @@
+__import__("setuptools").setup()

--- a/jupyter2repo/setup.py
+++ b/jupyter2repo/setup.py
@@ -1,1 +1,16 @@
 __import__("setuptools").setup()
+import json
+import os
+from jupyter_core.paths import jupyter_config_dir
+
+PLUGIN_ID = "jupyter2repo"
+config_dir = jupyter_config_dir()
+settings_path = os.path.join(config_dir, "lab", "user-settings", PLUGIN_ID, "plugin.json")
+os.makedirs(os.path.dirname(settings_path), exist_ok=True)
+
+settings_data = {
+    "GH_APP_ID": os.environ.get("GH_APP_ID"),
+    "GH_APP_URL": os.environ.get("GH_APP_URL"),
+}
+with open(settings_path, "w") as f:
+    json.dump(settings_data, f, indent=2)

--- a/jupyter2repo/setup.py
+++ b/jupyter2repo/setup.py
@@ -1,16 +1,1 @@
 __import__("setuptools").setup()
-import json
-import os
-from jupyter_core.paths import jupyter_config_dir
-
-PLUGIN_ID = "jupyter2repo"
-config_dir = jupyter_config_dir()
-settings_path = os.path.join(config_dir, "lab", "user-settings", PLUGIN_ID, "plugin.json")
-os.makedirs(os.path.dirname(settings_path), exist_ok=True)
-
-settings_data = {
-    "GH_APP_ID": os.environ.get("GH_APP_ID"),
-    "GH_APP_URL": os.environ.get("GH_APP_URL"),
-}
-with open(settings_path, "w") as f:
-    json.dump(settings_data, f, indent=2)

--- a/jupyter2repo/src/index.ts
+++ b/jupyter2repo/src/index.ts
@@ -39,6 +39,8 @@ import {
 } from '@jupyterlab/services/lib/kernel/messages';
 
 let outputArea: OutputArea | null = null;
+const githubRepoRegex =
+  /^https:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+(?:\.git)?$/;
 
 const plugin: JupyterFrontEndPlugin<void> = {
   id: 'jupyter2repo',
@@ -113,6 +115,14 @@ const plugin: JupyterFrontEndPlugin<void> = {
           );
           return;
         }
+
+        if (ghTargetRepo !== null && !githubRepoRegex.test(ghTargetRepo)) {
+          logMessage(
+            'Repo must be a valid HTTPS Github repository url of the format "https://github.com/user/repo.git"'
+          );
+          return;
+        }
+
         logMessage(
           `Using client ID ${ghClientID} and URL ${ghAppUrl}. Will push to ${ghTargetRepo}`
         );

--- a/jupyter2repo/src/index.ts
+++ b/jupyter2repo/src/index.ts
@@ -133,7 +133,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
         // but the user may not have adjusted the app settings yet to allow access to the specified repo.
         const proceed = await askUserConfirmation(
           'Confirm Permissions',
-          'Please confirm that you have granted the app access to the specified repo before continuing'
+          `Please confirm that you have granted the app access to the specified repo before continuing. This can be modified at ${ghAppUrl}`
         );
         if (proceed) {
           logMessage('Pushing requirements to repo');

--- a/jupyter2repo/src/index.ts
+++ b/jupyter2repo/src/index.ts
@@ -120,9 +120,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
         // TODO: We should skip this if we're already credentialed because it's definitely the most annoying part of the process
         // Could do this either by cloning the repo and attempting a push --dry-run or by snagging the access token from the temporary file or from the git config
         // Need to play around more with this
-
-        // TODO: This should just use the line magic cli option instead of calling main directly
-        const auth_command = `import gh_scoped_creds; gh_scoped_creds.main(['--client-id','${ghClientID}', '--github-app-url', '${ghAppUrl}'])`;
+        const auth_command = `!gh-scoped-creds --client-id='${ghClientID}' --github-app-url='${ghAppUrl}'`;
 
         const authFuture = session.kernel.requestExecute({
           code: auth_command
@@ -145,14 +143,14 @@ const plugin: JupyterFrontEndPlugin<void> = {
           // TODO: This hardcodes the version at python 3.11; we should probably derive this from whatever the kernel is running
           const gitCommands = `
         %%bash
-        git clone ${ghTargetRepo} ${targetDirectory}
-        cp ${notebookFilename} ${targetDirectory}/${notebookFilename}
+        git clone "${ghTargetRepo}" ${targetDirectory}
+        cp "${notebookFilename}" ${targetDirectory}/
         cd ${targetDirectory}
         pip freeze > requirements.txt
         echo $(python -c "import sys; print(f'python-{sys.version_info.major}.{sys.version_info.minor}')") > runtime.txt
         git add requirements.txt
         git add runtime.txt
-        git add ${notebookFilename}
+        git add "$(basename "${notebookFilename}")"
         echo 'Pushing to github'
         git commit -m 'Updating requirements.txt'
         git push origin main

--- a/jupyter2repo/src/index.ts
+++ b/jupyter2repo/src/index.ts
@@ -184,7 +184,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
         git add "$(basename "${notebookFilename}")"
         git add datasets
         echo 'Pushing to github'
-        git commit -m 'Updating requirements.txt'
+        git commit -m 'Update from notebook ${notebookFilename}'
         git push origin main
         echo 'Cleaning up checkout'
         cd ..

--- a/jupyter2repo/src/index.ts
+++ b/jupyter2repo/src/index.ts
@@ -9,8 +9,7 @@
  *
  * Limitations:
  * - This only persists the active notebook and running kernel's python requirements.txt
- * - This assumes that all jupyter runtimes are Python 3.13.
- * - The three persisted files are stored in the root of the target repo, meaning that right now this can only store 1 notebook per repo
+ * - The three persisted files are stored in the root of the target repo
  * - No provisions for data file storage
  */
 
@@ -77,7 +76,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
         if (!current) {
           await showDialog({
             title: 'Warning',
-            body: 'No active notebook - cannot.'
+            body: 'No active notebook - cannot save.'
           });
           return;
         }
@@ -153,7 +152,6 @@ const plugin: JupyterFrontEndPlugin<void> = {
         if (proceed) {
           logMessage('Pushing requirements to repo');
           const targetDirectory = UUID.uuid4();
-          // TODO: This hardcodes the version at python 3.11; we should probably derive this from whatever the kernel is running
           const gitCommands = `
         %%bash
         git clone "${ghTargetRepo}" ${targetDirectory}

--- a/jupyter2repo/src/index.ts
+++ b/jupyter2repo/src/index.ts
@@ -188,7 +188,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
         git push origin main
         echo 'Cleaning up checkout'
         cd ..
-        rm -rf ${targetDirectory} 
+        [ -n "${targetDirectory}" ] && rm -rf "${targetDirectory}"
         
         `;
 

--- a/jupyter2repo/src/index.ts
+++ b/jupyter2repo/src/index.ts
@@ -1,0 +1,228 @@
+/**
+ * Minimal JupyterLab extension to package a pip requirements.txt, runtime.txt and notebook file into a docker2repo repo from within a running jupyter notebook
+ * Prerequisites:
+ * - gh_scoped_creds installed in kernel (via %pip install gh-scoped-creds if necessary)
+ * - GH app configured per instructions at https://github.com/jupyterhub/gh-scoped-creds?tab=readme-ov-file#github-app-configuration
+ * - Instantiated repo that the contents will be pushed to.
+ * - N.B. This is all pretty unsafe; we're taking untrusted input and jamming it into the running kernel.
+ *   - Luckily if we only need a known MIT set up app install, we don't need to take as much user input for this. It's only useful for testing!
+ *
+ * Limitations:
+ * - This only persists the active notebook and running kernel's python requirements.txt
+ * - This assumes that all jupyter runtimes are Python 3.13.
+ * - The three persisted files are stored in the root of the target repo, meaning that right now this can only store 1 notebook per repo
+ * - No provisions for data file storage
+ */
+
+import {
+  JupyterFrontEnd,
+  JupyterFrontEndPlugin
+} from '@jupyterlab/application';
+
+import {
+  ICommandPalette,
+  InputDialog,
+  showDialog,
+  Dialog,
+  MainAreaWidget
+} from '@jupyterlab/apputils';
+import { INotebookTracker } from '@jupyterlab/notebook';
+import { KernelMessage } from '@jupyterlab/services';
+import { UUID } from '@lumino/coreutils';
+import { OutputArea, OutputAreaModel } from '@jupyterlab/outputarea';
+
+import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
+
+let outputArea: OutputArea | null = null;
+
+/**
+ * The extension plugin definition.
+ */
+const plugin: JupyterFrontEndPlugin<void> = {
+  id: 'python-runner-extension',
+  autoStart: true,
+  requires: [ICommandPalette, INotebookTracker, IRenderMimeRegistry],
+  activate: (
+    app: JupyterFrontEnd,
+    palette: ICommandPalette,
+    tracker: INotebookTracker,
+    rendermime: IRenderMimeRegistry
+  ) => {
+    console.log('Jupyter2Repo extension is activated!');
+
+    const { commands } = app;
+
+    // Command to run Python code
+    const commandId = 'python-runner:run';
+    commands.addCommand(commandId, {
+      label: 'Save Notebook to Github',
+      execute: async () => {
+        const current = tracker.currentWidget;
+        if (!current) {
+          await showDialog({
+            title: 'Warning',
+            body: 'No active notebook - cannot save.'
+          });
+          return;
+        }
+
+        const notebookFilename = current.context.localPath;
+
+        const session = current.sessionContext.session;
+        if (!session?.kernel) {
+          await showDialog({
+            title: 'Warning',
+            body: 'No active kernel - cannot save.'
+          });
+          return;
+        }
+
+        // Create OutputArea model
+        const model = new OutputAreaModel({ trusted: true });
+        outputArea = new OutputArea({
+          model,
+          rendermime: rendermime
+        });
+
+        // Wrap it in a MainAreaWidget
+        const widget = new MainAreaWidget({ content: outputArea });
+        widget.title.label = 'Log Panel';
+        widget.title.closable = true;
+
+        // Show panel immediately on startup
+        app.shell.add(widget, 'main');
+
+        const ghClientIDResponse = await InputDialog.getText({
+          title: 'Provide client ID for preconfigured GH app'
+        });
+
+        const ghClientID = ghClientIDResponse.value;
+
+        const ghAppUrlResponse = await InputDialog.getText({
+          title: 'Provide public app URL'
+        });
+        const ghAppUrl = ghAppUrlResponse.value;
+
+        const ghTargetRepoResponse = await InputDialog.getText({
+          title: 'Provide repo to push requirements to'
+        });
+        const ghTargetRepo = ghTargetRepoResponse.value;
+        if (![ghClientID, ghAppUrl, ghTargetRepo].every(isNotEmpty)) {
+          logMessage(
+            'All fields must be filled out in order to save notebook.'
+          );
+          return;
+        }
+        logMessage(
+          `Using client ID ${ghAppUrl} and URL ${ghAppUrl}. Will push to ${ghTargetRepo}`
+        );
+
+        // TODO: We should skip this if we're already credentialed because it's definitely the most annoying part of the process
+        // Could do this either by cloning the repo and attempting a push --dry-run or by snagging the access token from the temporary file or from the git config
+        // Need to play around more with this
+
+        // TODO: This should just use the line magic cli option instead of calling main directly
+        const auth_command = `import gh_scoped_creds
+          gh_scoped_creds.main(['--client-id','${ghClientID}', '--github-app-url', '${ghAppUrl}'])`;
+
+        const authFuture = session.kernel.requestExecute({
+          code: auth_command
+        });
+
+        authFuture.onIOPub = logToConsoleArea;
+
+        await authFuture.done;
+
+        // Clone target repo, create and add requirements.txt, push to repo.
+        // N.B. This confirmation is necessary because after completing the gh_scoped_creds command the kernel will have auth credentials,
+        // but the user may not have adjusted the app settings yet to allow access to the specified repo.
+        const proceed = await askUserConfirmation(
+          'Confirm Permissions',
+          'Please confirm that you have granted the app access to the specified repo before continuing'
+        );
+        if (proceed) {
+          logMessage('Pushing requirements to repo');
+          const targetDirectory = UUID.uuid4();
+          // TODO: This hardcodes the version at python 3.11; we should probably derive this from whatever the kernel is running
+          const gitCommands = `
+        %%bash
+        git clone ${ghTargetRepo} ${targetDirectory}
+        cp ${notebookFilename} ${targetDirectory}/${notebookFilename}
+        cd ${targetDirectory}
+        pip freeze > requirements.txt
+        echo 'python-3.11' > runtime.txt
+        git add requirements.txt
+        git add runtime.txt
+        git add ${notebookFilename}
+        echo 'Pushing to github'
+        git commit -m 'Updating requirements.txt'
+        git push origin main
+        echo 'Cleaning up checkout'
+        cd ..
+        rm -rf ${targetDirectory} 
+        
+        `;
+
+          const gitFuture = session.kernel.requestExecute({
+            code: gitCommands
+          });
+          gitFuture.onIOPub = logToConsoleArea;
+
+          await gitFuture.done;
+        } else {
+          logMessage('Aborting git operations');
+        }
+      }
+    });
+
+    // Add command to the palette
+    palette.addItem({ command: commandId, category: 'Extension Examples' });
+  }
+};
+
+const logToConsoleArea = (msg: KernelMessage.IIOPubMessage) => {
+  if (msg.header.msg_type === 'stream') {
+    logMessage((msg.content as any).text);
+  }
+  if (msg.header.msg_type === 'error') {
+    logMessage((msg.content as any).text);
+  }
+  if (msg.header.msg_type === 'execute_result') {
+    logMessage((msg.content as any).text);
+  }
+};
+
+function logMessage(text: string) {
+  if (!outputArea) {
+    console.warn('Log panel not created yet');
+    return;
+  }
+  // Add as a plain text output
+  outputArea.model.add({
+    output_type: 'stream',
+    name: 'stdout',
+    text: text + '\n'
+  });
+}
+
+function isNotEmpty(value: string | null | undefined) {
+  return value !== null && value !== undefined && value !== '';
+}
+
+async function askUserConfirmation(
+  title: string,
+  message: string
+): Promise<boolean> {
+  const result = await showDialog({
+    title: title,
+    body: message,
+    buttons: [
+      Dialog.cancelButton({ label: 'Cancel' }),
+      Dialog.okButton({ label: 'Confirm' })
+    ]
+  });
+
+  return result.button.accept; // true if OK clicked, false otherwise
+}
+
+export default plugin;

--- a/jupyter2repo/src/index.ts
+++ b/jupyter2repo/src/index.ts
@@ -35,11 +35,8 @@ import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 
 let outputArea: OutputArea | null = null;
 
-/**
- * The extension plugin definition.
- */
 const plugin: JupyterFrontEndPlugin<void> = {
-  id: 'python-runner-extension',
+  id: 'jupyter2repo',
   autoStart: true,
   requires: [ICommandPalette, INotebookTracker, IRenderMimeRegistry],
   activate: (
@@ -52,7 +49,6 @@ const plugin: JupyterFrontEndPlugin<void> = {
 
     const { commands } = app;
 
-    // Command to run Python code
     const commandId = 'python-runner:run';
     commands.addCommand(commandId, {
       label: 'Save Notebook to Github',
@@ -77,14 +73,13 @@ const plugin: JupyterFrontEndPlugin<void> = {
           return;
         }
 
-        // Create OutputArea model
+        // Create OutputArea model to use as a Log Panel.
         const model = new OutputAreaModel({ trusted: true });
         outputArea = new OutputArea({
           model,
           rendermime: rendermime
         });
 
-        // Wrap it in a MainAreaWidget
         const widget = new MainAreaWidget({ content: outputArea });
         widget.title.label = 'Log Panel';
         widget.title.closable = true;

--- a/jupyter2repo/style/base.css
+++ b/jupyter2repo/style/base.css
@@ -1,0 +1,5 @@
+/*
+    See the JupyterLab Developer Guide for useful CSS Patterns:
+
+    https://jupyterlab.readthedocs.io/en/stable/developer/css.html
+*/

--- a/jupyter2repo/style/index.css
+++ b/jupyter2repo/style/index.css
@@ -1,0 +1,1 @@
+@import url('base.css');

--- a/jupyter2repo/style/index.js
+++ b/jupyter2repo/style/index.js
@@ -1,0 +1,1 @@
+import './base.css';

--- a/jupyter2repo/tsconfig.json
+++ b/jupyter2repo/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "composite": true,
+    "declaration": true,
+    "esModuleInterop": true,
+    "incremental": true,
+    "jsx": "react",
+    "lib": ["DOM", "ES2018", "ES2020.Intl"],
+    "module": "esnext",
+    "moduleResolution": "node",
+    "noEmitOnError": true,
+    "noImplicitAny": true,
+    "noUnusedLocals": true,
+    "preserveWatchOutput": true,
+    "resolveJsonModule": true,
+    "outDir": "lib",
+    "rootDir": "src",
+    "strict": true,
+    "strictNullChecks": true,
+    "target": "ES2018",
+    "skipLibCheck": true
+  },
+  "include": ["src/*"]
+}


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/8028

### Description (What does it do?)
<!--- Describe your changes in detail -->
This is a proof of concept for a jupyter extension which uses [gh-scoped-credentials](https://github.com/jupyterhub/gh-scoped-creds) to automatically push the running notebook's ipynb file, all files under the root `datasets` directory and associated dependencies to a specified repo. 

### Screenshots (if appropriate):
Demo video:

https://github.com/user-attachments/assets/e19306c9-4594-48e6-b794-927ed77942b7



### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Prerequisites for setup:
- [Jupyterhub](https://github.com/jupyterhub/jupyterhub) running locally
- A github application configured [as detailed in gh-scoped-creds readme](https://github.com/jupyterhub/gh-scoped-creds?tab=readme-ov-file#github-app-configuration)
- A test repo to persist data to. I would strongly suggest this be empty as the extension will attempt to create `requirements.txt`, `runtime.txt` and the notebook file in the root of the repo.
- You need to specify the following `overrides.json` in your application's settings directory:
```
{
  "jupyter2repo:plugin": {
    "GH_APP_ID": "YOUR_ID_FROM_SECRETS",
    "GH_APP_URL": "https://your.app/url"
  }
}
```
The settings directory can be found using `jupyter lab path` 

E2E test
- Install the extension in jupyterhub. In my case, this was a matter of running `pip install -e ol-notebook-extensions/jupyter2repo`, but your mileage will vary depending on how you're running Jupyterhub.
- Start jupyterhub
- Navigate to your workspace and select a notebook.
- Select `Activate Command Palette` from the View menu and select `Save Notebook to Github`. Follow the instructions on screen.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->
This is intended as a proof of concept. It is sufficient to validate the approach from a technical perspective, but below are a non-exhaustive list of changes we can consider to improve the user experience or shore up the functionality:
- ~We can have a form take all three inputs at once.~ As we've settled on a per-course repo layout within the MITx org, we should be able to take the app-specific values as config values at install time. We should only need one bit of user supplied info.
- ~We can remove some inputs, if we settle on a specific setup for target repos (i.e. if we require all target repos to be within the mitx org, we would only need the target repo).~ See above.
- There's no input validation at the moment, so it's easy to break by entering incorrect or malicious data. **This is not safe to run in production at the moment.**
- ~This makes no provision for storing any data files that may be important to the notebook. Discussion is ongoing at https://github.com/mitodl/hq/issues/8028#issuecomment-3184844533~ It will persist any files put under a `datasets` directory - this will be the convention going forward.
- ~Due to where it stores the files, this is currently only capable of storing one notebook per repo. We could change the conventions for where we persist the files to organize multiple notebooks and kernels.~ We've decided upon a repo per-course, so we should be able to persist multiple notebooks and a single kernel per repo. See discussion at https://github.com/mitodl/hq/issues/8028#issuecomment-3180597032
- It also assumes that the target repo is already created before this is run. We likely want a template repo or other simple way to stand up repos with the desired structure.
- Right now, this uses an older version of typescript and has `skipLibCheck` specified - this is due to [some recent](https://github.com/jupyterlab/extension-template/issues/108) [updates](https://discourse.jupyter.org/t/cant-build-install-my-own-extension-any-more-type-uint8array-is-not-generic/37036) that resulted in some dependency installation problems in the extension template repos.


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
