### PR TITLE
Changes the link for the logo in jupyter notebooks

### DIFF
--- a/ol-themed-jupyter/package.json
+++ b/ol-themed-jupyter/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ol-themed-jupyter",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "Provides MIT OpenLearning themes for Jupyter",
     "keywords": [
         "jupyter",

--- a/ol-themed-jupyter/src/index.ts
+++ b/ol-themed-jupyter/src/index.ts
@@ -21,9 +21,8 @@ const plugin: JupyterFrontEndPlugin<void> = {
   description: 'Provides MIT OpenLearning themes for Jupyter',
   autoStart: true,
   activate: (app: JupyterFrontEnd) => {
-    const baseUrl = PageConfig.getBaseUrl();
     const node = document.createElement('a');
-    node.href = `${baseUrl}tree`;
+    node.href = `https://learn.mit.edu/dashboard`;
     node.target = '_blank';
     node.rel = 'noopener noreferrer';
     const logo = new Widget({ node });


### PR DESCRIPTION
Per [Peter's request](https://mitodl.slack.com/archives/C09DRCSS9S6/p1760732623106419), changes the link for the logo to point at `https://learn.mit.edu/dashboard`
