### PR TITLE
Save to s3 extension

### DIFF
--- a/ol-jupyter-authoring/ol_jupyter_authoring/routes.py
+++ b/ol-jupyter-authoring/ol_jupyter_authoring/routes.py
@@ -11,7 +11,7 @@ import tornado
 
 # TODO: We need to set up a real bucket before we can set this
 # Can pull from env var in the meantime.
-NOTEBOOK_BUCKET = os.environ.get("NOTEBOOK_BUCKET")
+NOTEBOOK_BUCKET = os.environ.get('NOTEBOOK_BUCKET')
 
 
 class SaveToS3Handler(APIHandler):
@@ -55,7 +55,7 @@ class SaveToS3Handler(APIHandler):
             archive_start = time.time()
             filename, archive = self._get_workspace_directory_archive()
             archive_end = time.time()
-            self.log.info("Created workspace archive in %.2f seconds", archive_end - archive_start)
+            self.log.info('Created workspace archive in %.2f seconds', archive_end - archive_start)
 
             # We need to think through how auth plugs in here so I can read the current user in a semi-secure way
             current_username = self.current_user.username
@@ -68,21 +68,21 @@ class SaveToS3Handler(APIHandler):
             self.sync_file_to_s3(filename, NOTEBOOK_BUCKET, s3_key)
             s3_sync_end = time.time()
 
-            self.log.info("Synced workspace archive to S3 in %.2f seconds", s3_sync_end - s3_sync_start)
+            self.log.info('Synced workspace archive to S3 in %.2f seconds', s3_sync_end - s3_sync_start)
             self.cleanup_tar_file(filename)
 
             self.finish(json.dumps({
-                "data": ("Saved {} to S3 at {}".format(self.settings.get('serverapp').root_dir, s3_key)),
+                'data': ('Saved {} to S3 at {}'.format(self.settings.get('serverapp').root_dir, s3_key)),
             }))
         except Exception as e:
             self.finish(json.dumps({'error': str(e)}))
 
 
 def setup_route_handlers(web_app):
-    host_pattern = ".*$"
-    base_url = web_app.settings["base_url"]
+    host_pattern = '.*$'
+    base_url = web_app.settings['base_url']
 
-    s3_save_pattern = url_path_join(base_url, "ol-jupyter-authoring", "s3-save")
+    s3_save_pattern = url_path_join(base_url, 'ol-jupyter-authoring', 's3-save')
     handlers = [(s3_save_pattern, SaveToS3Handler)]
 
     web_app.add_handlers(host_pattern, handlers)

--- a/ol-jupyter-authoring/ol_jupyter_authoring/routes.py
+++ b/ol-jupyter-authoring/ol_jupyter_authoring/routes.py
@@ -9,7 +9,7 @@ from jupyter_server.utils import url_path_join
 import boto3
 import tornado
 
-NOTEBOOK_BUCKET = ''
+NOTEBOOK_BUCKET = 'ol-devops-sandbox'
 
 
 class SaveToS3Handler(APIHandler):
@@ -29,6 +29,7 @@ class SaveToS3Handler(APIHandler):
         return os.path.join(workspace_dir, filename), tar
 
     def sync_file_to_s3(self, local_file_path, bucket_name, s3_key):
+        # TODO: This only runs if AWS credentials are discoverable on the server (i.e. .credentials or IAM role)
         s3 = boto3.client('s3')
         s3.upload_file(local_file_path, bucket_name, s3_key)
 
@@ -39,7 +40,7 @@ class SaveToS3Handler(APIHandler):
     def get(self):
 
         '''
-        Saves workspace to an S3 bucket
+        Saves workspace to an S3 bucket. **This is currently synchronous**
         - Compress an archive of entire workspace
         - Upload the archive to S3
         - Return S3 URL to client?
@@ -47,28 +48,34 @@ class SaveToS3Handler(APIHandler):
         '''
 
         cleanup = True # TODO: Once we're done testing, we can drop these flag and always clean up
-        upload = False
+        upload = True
 
-        archive_start = time.time()
-        filename, archive = self._get_workspace_directory_archive()
-        archive_end = time.time()
-        self.log.info("Created workspace archive in %.2f seconds", archive_end - archive_start)
-        # We need to think through how auth plugs in here so I can read the current user in a semi-secure way
-        current_username = self.current_user.username
-        # Ideally the course name will be populated automatically if you start from a WIP course
-        # But we'll allow users to override it if necessary
-        course_name = self.get_argument('course','default_course')
-        s3_key = f'{current_username}/{course_name}'
-        s3_sync_start = time.time()
-        if upload:
-            self.sync_file_to_s3(filename, NOTEBOOK_BUCKET, s3_key)
-        s3_sync_end = time.time()
-        self.log.info("Synced workspace archive to S3 in %.2f seconds", s3_sync_end - s3_sync_start)
-        if cleanup:
-            self.cleanup_tar_file(filename)
-        self.finish(json.dumps({
-            "data": ( "Saved {} to S3 at {}".format(self.settings.get('serverapp').root_dir, s3_key)),
-        }))
+        try:
+            archive_start = time.time()
+            filename, archive = self._get_workspace_directory_archive()
+            archive_end = time.time()
+            self.log.info("Created workspace archive in %.2f seconds", archive_end - archive_start)
+            # We need to think through how auth plugs in here so I can read the current user in a semi-secure way
+            current_username = self.current_user.username
+            # Ideally the course name will be populated automatically if you start from a WIP course
+            # But we'll allow users to override it if necessary
+            course_name = self.get_argument('course','default_course')
+            s3_key = f'ol-jupyter-courses/{current_username}/{course_name}.tar.gz'
+            s3_sync_start = time.time()
+            if upload:
+                self.sync_file_to_s3(filename, NOTEBOOK_BUCKET, s3_key)
+            s3_sync_end = time.time()
+            self.log.info("Synced workspace archive to S3 in %.2f seconds", s3_sync_end - s3_sync_start)
+
+            if cleanup:
+                self.cleanup_tar_file(filename)
+
+            self.finish(json.dumps({
+                "data": ("Saved {} to S3 at {}".format(self.settings.get('serverapp').root_dir, s3_key)),
+            }))
+        except Exception as e:
+            # TODO: Need to figure out what the idiomatic approach for error handling is in Jupyter
+            self.finish(json.dumps({'error': str(e)}))
 
 
 def setup_route_handlers(web_app):

--- a/ol-jupyter-authoring/ol_jupyter_authoring/routes.py
+++ b/ol-jupyter-authoring/ol_jupyter_authoring/routes.py
@@ -40,6 +40,8 @@ class SaveToS3Handler(APIHandler):
     def cleanup_tar_file(self, filename):
         os.remove(filename)
 
+    # TODO: Could make async. This is a potentially long-running operation
+    # TODO: Could make a POST. GET isn't really appropriate for an operation that modifies state
     @tornado.web.authenticated
     def get(self):
 

--- a/ol-jupyter-authoring/ol_jupyter_authoring/routes.py
+++ b/ol-jupyter-authoring/ol_jupyter_authoring/routes.py
@@ -1,13 +1,38 @@
 import json
+import tarfile
+import uuid
+import os
 
 from jupyter_server.base.handlers import APIHandler
 from jupyter_server.utils import url_path_join
+import boto3
 import tornado
+
+NOTEBOOK_BUCKET = ''
 
 class SaveToS3Handler(APIHandler):
     # The following decorator should be present on all verb methods (head, get, post,
     # patch, put, delete, options) to ensure only authorized user can request the
     # Jupyter server
+
+    def _get_workspace_directory_archive(self):
+        # Get the workspace directory (Jupyter server root)
+        # TODO: We may need to do more here if we decide not to expose the Dockerfile and requirements files
+        # This might involve cramming a requirements file in a hidden subdirectory before archiving
+        workspace_dir = self.settings.get('serverapp').root_dir
+        filename = '{}.tar.gz'.format(uuid.uuid4())
+        tar = tarfile.open(filename, mode='w:gz')
+        tar.add(workspace_dir, arcname=os.path.basename(workspace_dir))
+        tar.close()
+        return os.path.join(workspace_dir, filename), tar
+
+    def sync_file_to_s3(self, local_file_path, bucket_name, s3_key):
+        s3 = boto3.client('s3')
+        s3.upload_file(local_file_path, bucket_name, s3_key)
+
+    def cleanup_tar_file(self, filename):
+        os.remove(filename)
+
     @tornado.web.authenticated
     def get(self):
 
@@ -18,8 +43,21 @@ class SaveToS3Handler(APIHandler):
         - Return S3 URL to client?
         '''
 
+        cleanup = False # TODO: Once we're done testing, we can drop this flag and always clean up
+        filename, archive = self._get_workspace_directory_archive()
+        # TODO: Right now this is probably not gonna work out of box.
+        # We need to think through how auth plugs in here so I can read the current user in a semi-secure way
+        current_username = self.current_user.username
+        # Ideally the course name will be populated automatically if you start from a WIP course
+        # We'll allow users to override it if necessary. Need UI to do this.
+        # TODO: Pipe a "course name" argument in from the client.
+        course_name = 'default_course'
+        s3_key = f'{current_username}/{course_name}'
+        self.sync_file_to_s3(filename, NOTEBOOK_BUCKET, s3_key)
+        if cleanup:
+            self.cleanup_tar_file(filename)
         self.finish(json.dumps({
-            "data": ( "Saved to S3"),
+            "data": ( "Saved {} to S3".format(self.settings.get('serverapp').root_dir)),
         }))
 
 

--- a/ol-jupyter-authoring/ol_jupyter_authoring/routes.py
+++ b/ol-jupyter-authoring/ol_jupyter_authoring/routes.py
@@ -43,7 +43,7 @@ class SaveToS3Handler(APIHandler):
     # TODO: Could make async. This is a potentially long-running operation
     # TODO: Could make a POST. GET isn't really appropriate for an operation that modifies state
     @tornado.web.authenticated
-    def get(self):
+    async def post(self):
 
         '''
         Saves workspace to an S3 bucket. **This is currently synchronous**
@@ -73,11 +73,11 @@ class SaveToS3Handler(APIHandler):
             self.log.info('Synced workspace archive to S3 in %.2f seconds', s3_sync_end - s3_sync_start)
             self.cleanup_tar_file(filename)
 
-            self.finish(json.dumps({
+            await self.finish(json.dumps({
                 'data': ('Saved {} to S3 at {}'.format(self.settings.get('serverapp').root_dir, s3_key)),
             }))
         except Exception as e:
-            self.finish(json.dumps({'error': str(e)}))
+            await self.finish(json.dumps({'error': str(e)}))
 
 
 def setup_route_handlers(web_app):

--- a/ol-jupyter-authoring/ol_jupyter_authoring/routes.py
+++ b/ol-jupyter-authoring/ol_jupyter_authoring/routes.py
@@ -40,8 +40,6 @@ class SaveToS3Handler(APIHandler):
     def cleanup_tar_file(self, filename):
         os.remove(filename)
 
-    # TODO: Could make async. This is a potentially long-running operation
-    # TODO: Could make a POST. GET isn't really appropriate for an operation that modifies state
     @tornado.web.authenticated
     async def post(self):
 

--- a/ol-jupyter-authoring/ol_jupyter_authoring/routes.py
+++ b/ol-jupyter-authoring/ol_jupyter_authoring/routes.py
@@ -21,6 +21,8 @@ class SaveToS3Handler(APIHandler):
         # Get the workspace directory (Jupyter server root)
         # TODO: We may need to do more here if we decide not to expose the Dockerfile and requirements files
         # This might involve cramming a requirements file in a hidden subdirectory before archiving
+        # In general, we're going to persist hidden directories with this command
+        # but we'll drop anything we don't expressly add in the dockerfile (i.e. .ipynb_checkpoints)
         workspace_dir = self.settings.get('serverapp').root_dir
         filename = '{}.tar.gz'.format(uuid.uuid4())
         tar = tarfile.open(filename, mode='w:gz')

--- a/ol-jupyter-authoring/ol_jupyter_authoring/routes.py
+++ b/ol-jupyter-authoring/ol_jupyter_authoring/routes.py
@@ -4,18 +4,22 @@ from jupyter_server.base.handlers import APIHandler
 from jupyter_server.utils import url_path_join
 import tornado
 
-class HelloRouteHandler(APIHandler):
+class SaveToS3Handler(APIHandler):
     # The following decorator should be present on all verb methods (head, get, post,
     # patch, put, delete, options) to ensure only authorized user can request the
     # Jupyter server
     @tornado.web.authenticated
     def get(self):
+
+        '''
+        Saves workspace to an S3 bucket
+        - Compress an archive of entire workspace
+        - Upload the archive to S3
+        - Return S3 URL to client?
+        '''
+
         self.finish(json.dumps({
-            "data": (
-                "Hello, world!"
-                " This is the '/ol-jupyter-authoring/hello' endpoint."
-                " Try visiting me in your browser!"
-            ),
+            "data": ( "Saved to S3"),
         }))
 
 
@@ -23,7 +27,7 @@ def setup_route_handlers(web_app):
     host_pattern = ".*$"
     base_url = web_app.settings["base_url"]
 
-    hello_route_pattern = url_path_join(base_url, "ol-jupyter-authoring", "hello")
-    handlers = [(hello_route_pattern, HelloRouteHandler)]
+    s3_save_pattern = url_path_join(base_url, "ol-jupyter-authoring", "s3-save")
+    handlers = [(s3_save_pattern, SaveToS3Handler)]
 
     web_app.add_handlers(host_pattern, handlers)

--- a/ol-jupyter-authoring/ol_jupyter_authoring/routes.py
+++ b/ol-jupyter-authoring/ol_jupyter_authoring/routes.py
@@ -2,6 +2,7 @@ import json
 import tarfile
 import uuid
 import os
+import time
 
 from jupyter_server.base.handlers import APIHandler
 from jupyter_server.utils import url_path_join
@@ -9,6 +10,7 @@ import boto3
 import tornado
 
 NOTEBOOK_BUCKET = ''
+
 
 class SaveToS3Handler(APIHandler):
     # The following decorator should be present on all verb methods (head, get, post,
@@ -41,23 +43,31 @@ class SaveToS3Handler(APIHandler):
         - Compress an archive of entire workspace
         - Upload the archive to S3
         - Return S3 URL to client?
+        - Clean up local archive file
         '''
 
-        cleanup = False # TODO: Once we're done testing, we can drop this flag and always clean up
+        cleanup = True # TODO: Once we're done testing, we can drop these flag and always clean up
+        upload = False
+
+        archive_start = time.time()
         filename, archive = self._get_workspace_directory_archive()
-        # TODO: Right now this is probably not gonna work out of box.
+        archive_end = time.time()
+        self.log.info("Created workspace archive in %.2f seconds", archive_end - archive_start)
         # We need to think through how auth plugs in here so I can read the current user in a semi-secure way
         current_username = self.current_user.username
         # Ideally the course name will be populated automatically if you start from a WIP course
-        # We'll allow users to override it if necessary. Need UI to do this.
-        # TODO: Pipe a "course name" argument in from the client.
-        course_name = 'default_course'
+        # But we'll allow users to override it if necessary
+        course_name = self.get_argument('course','default_course')
         s3_key = f'{current_username}/{course_name}'
-        self.sync_file_to_s3(filename, NOTEBOOK_BUCKET, s3_key)
+        s3_sync_start = time.time()
+        if upload:
+            self.sync_file_to_s3(filename, NOTEBOOK_BUCKET, s3_key)
+        s3_sync_end = time.time()
+        self.log.info("Synced workspace archive to S3 in %.2f seconds", s3_sync_end - s3_sync_start)
         if cleanup:
             self.cleanup_tar_file(filename)
         self.finish(json.dumps({
-            "data": ( "Saved {} to S3".format(self.settings.get('serverapp').root_dir)),
+            "data": ( "Saved {} to S3 at {}".format(self.settings.get('serverapp').root_dir, s3_key)),
         }))
 
 

--- a/ol-jupyter-authoring/ol_jupyter_authoring/routes.py
+++ b/ol-jupyter-authoring/ol_jupyter_authoring/routes.py
@@ -10,8 +10,8 @@ import boto3
 import tornado
 
 # TODO: We need to set up a real bucket before we can set this
-# Can pull from env var if we want these segmented per-environment.
-NOTEBOOK_BUCKET = ''
+# Can pull from env var in the meantime.
+NOTEBOOK_BUCKET = os.environ.get("NOTEBOOK_BUCKET")
 
 
 class SaveToS3Handler(APIHandler):

--- a/ol-jupyter-authoring/ol_jupyter_authoring/routes.py
+++ b/ol-jupyter-authoring/ol_jupyter_authoring/routes.py
@@ -9,7 +9,9 @@ from jupyter_server.utils import url_path_join
 import boto3
 import tornado
 
-NOTEBOOK_BUCKET = 'ol-devops-sandbox'
+# TODO: We need to set up a real bucket before we can set this
+# Can pull from env var if we want these segmented per-environment.
+NOTEBOOK_BUCKET = ''
 
 
 class SaveToS3Handler(APIHandler):

--- a/ol-jupyter-authoring/ol_jupyter_authoring/routes.py
+++ b/ol-jupyter-authoring/ol_jupyter_authoring/routes.py
@@ -31,7 +31,7 @@ class SaveToS3Handler(APIHandler):
         return os.path.join(workspace_dir, filename), tar
 
     def sync_file_to_s3(self, local_file_path, bucket_name, s3_key):
-        # TODO: This only runs if AWS credentials are discoverable on the server (i.e. .credentials or IAM role)
+        # This only functions if AWS credentials are discoverable on the server (i.e. .credentials or IAM role)
         s3 = boto3.client('s3')
         s3.upload_file(local_file_path, bucket_name, s3_key)
 
@@ -49,34 +49,30 @@ class SaveToS3Handler(APIHandler):
         - Clean up local archive file
         '''
 
-        cleanup = True # TODO: Once we're done testing, we can drop these flag and always clean up
-        upload = True
-
         try:
             archive_start = time.time()
             filename, archive = self._get_workspace_directory_archive()
             archive_end = time.time()
             self.log.info("Created workspace archive in %.2f seconds", archive_end - archive_start)
+
             # We need to think through how auth plugs in here so I can read the current user in a semi-secure way
             current_username = self.current_user.username
+
             # Ideally the course name will be populated automatically if you start from a WIP course
             # But we'll allow users to override it if necessary
             course_name = self.get_argument('course','default_course')
             s3_key = f'ol-jupyter-courses/{current_username}/{course_name}.tar.gz'
             s3_sync_start = time.time()
-            if upload:
-                self.sync_file_to_s3(filename, NOTEBOOK_BUCKET, s3_key)
+            self.sync_file_to_s3(filename, NOTEBOOK_BUCKET, s3_key)
             s3_sync_end = time.time()
-            self.log.info("Synced workspace archive to S3 in %.2f seconds", s3_sync_end - s3_sync_start)
 
-            if cleanup:
-                self.cleanup_tar_file(filename)
+            self.log.info("Synced workspace archive to S3 in %.2f seconds", s3_sync_end - s3_sync_start)
+            self.cleanup_tar_file(filename)
 
             self.finish(json.dumps({
                 "data": ("Saved {} to S3 at {}".format(self.settings.get('serverapp').root_dir, s3_key)),
             }))
         except Exception as e:
-            # TODO: Need to figure out what the idiomatic approach for error handling is in Jupyter
             self.finish(json.dumps({'error': str(e)}))
 
 

--- a/ol-jupyter-authoring/package.json
+++ b/ol-jupyter-authoring/package.json
@@ -59,6 +59,7 @@
     "dependencies": {
         "@jupyterlab/application": "^4.0.0",
         "@jupyterlab/coreutils": "^6.0.0",
+        "@jupyterlab/mainmenu": "^4.4.10",
         "@jupyterlab/services": "^7.0.0",
         "@jupyterlab/settingregistry": "^4.0.0"
     },

--- a/ol-jupyter-authoring/pyproject.toml
+++ b/ol-jupyter-authoring/pyproject.toml
@@ -23,7 +23,8 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "jupyter_server>=2.4.0,<3"
+    "boto3>=1.40.64",
+    "jupyter_server>=2.4.0,<3",
 ]
 dynamic = ["version", "description", "authors", "keywords"]
 

--- a/ol-jupyter-authoring/src/index.ts
+++ b/ol-jupyter-authoring/src/index.ts
@@ -66,7 +66,8 @@ const plugin: JupyterFrontEndPlugin<void> = {
         }
 
         const courseName = await InputDialog.getText({
-          title: 'Enter Course Name'
+          title: 'Enter Course Name',
+          required: true
         });
 
         if (!courseName.button.accept) {

--- a/ol-jupyter-authoring/src/index.ts
+++ b/ol-jupyter-authoring/src/index.ts
@@ -2,7 +2,7 @@ import {
   JupyterFrontEnd,
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
-
+import { InputDialog } from '@jupyterlab/apputils';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { IMainMenu } from '@jupyterlab/mainmenu';
 import { requestAPI } from './request';
@@ -48,9 +48,13 @@ const plugin: JupyterFrontEndPlugin<void> = {
     }
     app.commands.addCommand(CommandIDs.saveToS3, {
       label: 'Save to S3',
-      execute: args => {
+      execute: async args => {
         console.log('Save to S3 command executed with args:', args);
-        requestAPI<any>('s3-save')
+        const courseName = await InputDialog.getText({
+          title: 'Enter Course Name'
+        });
+
+        requestAPI<any>(`s3-save?course=${courseName.value}`)
           .then(data => {
             console.log(data);
           })

--- a/ol-jupyter-authoring/src/index.ts
+++ b/ol-jupyter-authoring/src/index.ts
@@ -2,7 +2,12 @@ import {
   JupyterFrontEnd,
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
-import { InputDialog } from '@jupyterlab/apputils';
+import {
+  InputDialog,
+  showDialog,
+  showErrorMessage,
+  Dialog
+} from '@jupyterlab/apputils';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { IMainMenu } from '@jupyterlab/mainmenu';
 import { requestAPI } from './request';
@@ -50,17 +55,27 @@ const plugin: JupyterFrontEndPlugin<void> = {
       label: 'Save to S3',
       execute: async args => {
         console.log('Save to S3 command executed with args:', args);
+        // TODO: Need to prompt users to save and let them exit if they haven't
         const courseName = await InputDialog.getText({
           title: 'Enter Course Name'
         });
 
         requestAPI<any>(`s3-save?course=${courseName.value}`)
           .then(data => {
+            // TODO: Need to handle well-formed errors from the server
+            // This catch will only work if there's an unhandled error
+            showDialog({
+              title: 'Save to S3',
+              body: 'Notebook saved to S3 successfully.',
+              buttons: [Dialog.okButton()]
+            });
             console.log(data);
           })
           .catch(reason => {
-            console.error(
-              `The ol_jupyter_authoring server extension appears to be missing.\n${reason}`
+            showErrorMessage(
+              'Save to S3 Failed',
+              `Failed to save notebook to S3. See console for details.\n${reason}`,
+              [Dialog.okButton()]
             );
           });
       }

--- a/ol-jupyter-authoring/src/index.ts
+++ b/ol-jupyter-authoring/src/index.ts
@@ -85,7 +85,6 @@ const plugin: JupyterFrontEndPlugin<void> = {
               );
               return;
             } else {
-              // This catch will only work if there's an unhandled error
               showDialog({
                 title: 'Save to S3',
                 body: 'Notebook saved to S3 successfully.',
@@ -95,6 +94,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
             }
           })
           .catch(reason => {
+            // This block covers unhandled errors.
             showErrorMessage(
               'Save to S3 Failed',
               `Failed to save notebook to S3. See console for details. \n${reason}`,

--- a/ol-jupyter-authoring/src/index.ts
+++ b/ol-jupyter-authoring/src/index.ts
@@ -76,21 +76,31 @@ const plugin: JupyterFrontEndPlugin<void> = {
 
         requestAPI<any>(`s3-save?course=${courseName.value}`)
           .then(data => {
-            // TODO: Need to handle well-formed errors from the server
-            // This catch will only work if there's an unhandled error
-            showDialog({
-              title: 'Save to S3',
-              body: 'Notebook saved to S3 successfully.',
-              buttons: [Dialog.okButton()]
-            });
-            console.log(data);
+            if (data.error) {
+              console.log('Error saving to S3:', data.error);
+              showErrorMessage(
+                'Save to S3 Failed',
+                `Failed to save notebook to S3. See console for details. \n${data.error}`,
+                [Dialog.okButton()]
+              );
+              return;
+            } else {
+              // This catch will only work if there's an unhandled error
+              showDialog({
+                title: 'Save to S3',
+                body: 'Notebook saved to S3 successfully.',
+                buttons: [Dialog.okButton()]
+              });
+              console.log(data);
+            }
           })
           .catch(reason => {
             showErrorMessage(
               'Save to S3 Failed',
-              `Failed to save notebook to S3. See console for details.\n${reason}`,
+              `Failed to save notebook to S3. See console for details. \n${reason}`,
               [Dialog.okButton()]
             );
+            return;
           });
       }
     });

--- a/ol-jupyter-authoring/src/index.ts
+++ b/ol-jupyter-authoring/src/index.ts
@@ -4,40 +4,71 @@ import {
 } from '@jupyterlab/application';
 
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
-
+import { IMainMenu } from '@jupyterlab/mainmenu';
 import { requestAPI } from './request';
 
 /**
  * Initialization data for the ol-jupyter-authoring extension.
  */
+
+namespace CommandIDs {
+  export const saveToS3 = 'filebrowser:s3-save';
+}
+
 const plugin: JupyterFrontEndPlugin<void> = {
   id: 'ol-jupyter-authoring:plugin',
-  description: 'Jupyter authoring extension for OpenLearning-hosted Jupyter notebooks ',
+  description:
+    'Jupyter authoring extension for OpenLearning-hosted Jupyter notebooks ',
   autoStart: true,
+  requires: [IMainMenu],
   optional: [ISettingRegistry],
-  activate: (app: JupyterFrontEnd, settingRegistry: ISettingRegistry | null) => {
+  activate: (
+    app: JupyterFrontEnd,
+    mainMenu: IMainMenu,
+    settingRegistry: ISettingRegistry | null
+  ) => {
     console.log('JupyterLab extension ol-jupyter-authoring is activated!');
 
     if (settingRegistry) {
       settingRegistry
         .load(plugin.id)
         .then(settings => {
-          console.log('ol-jupyter-authoring settings loaded:', settings.composite);
+          console.log(
+            'ol-jupyter-authoring settings loaded:',
+            settings.composite
+          );
+          // This shouldn't be necessary long term, but for testing it may be useful to keep settings user editable.
         })
         .catch(reason => {
-          console.error('Failed to load settings for ol-jupyter-authoring.', reason);
+          console.error(
+            'Failed to load settings for ol-jupyter-authoring.',
+            reason
+          );
         });
     }
-
-    requestAPI<any>('hello')
-      .then(data => {
-        console.log(data);
-      })
-      .catch(reason => {
-        console.error(
-          `The ol_jupyter_authoring server extension appears to be missing.\n${reason}`
-        );
-      });
+    app.commands.addCommand(CommandIDs.saveToS3, {
+      label: 'Save to S3',
+      execute: args => {
+        console.log('Save to S3 command executed with args:', args);
+        requestAPI<any>('s3-save')
+          .then(data => {
+            console.log(data);
+          })
+          .catch(reason => {
+            console.error(
+              `The ol_jupyter_authoring server extension appears to be missing.\n${reason}`
+            );
+          });
+      }
+    });
+    mainMenu.fileMenu.addGroup(
+      [
+        {
+          command: CommandIDs.saveToS3
+        }
+      ],
+      40
+    );
   }
 };
 

--- a/ol-jupyter-authoring/src/index.ts
+++ b/ol-jupyter-authoring/src/index.ts
@@ -17,7 +17,7 @@ import { requestAPI } from './request';
  */
 
 namespace CommandIDs {
-  export const saveToS3 = 'filebrowser:s3-save';
+  export const saveToS3 = 'ol-jupyter-authoring:s3-save';
 }
 
 const plugin: JupyterFrontEndPlugin<void> = {
@@ -76,7 +76,9 @@ const plugin: JupyterFrontEndPlugin<void> = {
           return;
         }
 
-        requestAPI<any>(`s3-save?course=${courseName.value}`)
+        requestAPI<any>(`s3-save?course=${courseName.value}`, {
+          method: 'POST'
+        })
           .then(data => {
             if (data.error) {
               console.log('Error saving to S3:', data.error);

--- a/ol-jupyter-authoring/src/index.ts
+++ b/ol-jupyter-authoring/src/index.ts
@@ -65,12 +65,13 @@ const plugin: JupyterFrontEndPlugin<void> = {
           return;
         }
 
+        // TODO: Required doesn't actually stop you from pressing OK with no text...
         const courseName = await InputDialog.getText({
           title: 'Enter Course Name',
           required: true
         });
 
-        if (!courseName.button.accept) {
+        if (!courseName.button.accept || !courseName.value) {
           // If they select cancel, don't attempt to upload to S3
           return;
         }

--- a/ol-jupyter-authoring/src/index.ts
+++ b/ol-jupyter-authoring/src/index.ts
@@ -55,10 +55,24 @@ const plugin: JupyterFrontEndPlugin<void> = {
       label: 'Save to S3',
       execute: async args => {
         console.log('Save to S3 command executed with args:', args);
-        // TODO: Need to prompt users to save and let them exit if they haven't
+        const confirmedSave = await showDialog({
+          title: 'Save to S3',
+          body: "Please ensure you've saved your work before continuing with upload.",
+          buttons: [Dialog.okButton(), Dialog.cancelButton()]
+        });
+
+        if (!confirmedSave.button.accept) {
+          return;
+        }
+
         const courseName = await InputDialog.getText({
           title: 'Enter Course Name'
         });
+
+        if (!courseName.button.accept) {
+          // If they select cancel, don't attempt to upload to S3
+          return;
+        }
 
         requestAPI<any>(`s3-save?course=${courseName.value}`)
           .then(data => {


### PR DESCRIPTION
### Description (What does it do?)
This PR contains a working implementation for saving a Jupyter server's root directory to S3 in a `tar.gz` file. 

### Screenshots (if appropriate):
<img width="844" height="889" alt="Screenshot 2025-11-04 at 2 57 46 PM" src="https://github.com/user-attachments/assets/c897868a-8320-4d8c-b722-d7ea6bc4c6de" />
<img width="1153" height="863" alt="Screenshot 2025-11-04 at 2 57 51 PM" src="https://github.com/user-attachments/assets/86760b22-1d75-40e2-a523-bc28898dacf2" />
<img width="1179" height="866" alt="Screenshot 2025-11-04 at 2 58 01 PM" src="https://github.com/user-attachments/assets/d170c9f5-85d4-41f3-9816-f2b3bbea3722" />
<img width="1368" height="873" alt="Screenshot 2025-11-04 at 2 58 59 PM" src="https://github.com/user-attachments/assets/bd9c14b6-9d51-4527-95a6-914c0ac1ec5f" />
<img width="1725" height="574" alt="Screenshot 2025-11-04 at 2 59 19 PM" src="https://github.com/user-attachments/assets/68433db1-6ef2-46e3-9711-7055c2565b9e" />


### How can this be tested?
- Check out this branch. Set an environment variable `NOTEBOOK_BUCKET` as the name of an S3 Bucket you have access to.
- Ensure that you have [AWS credentials configured for your machine](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#configuring-credentials).
  - The plugin will rely on an attached role for IAM access in production. For testing, I recommend environment variables, credential files or config files to emulate the behavior. As a rule of thumb if you can access your S3 bucket via `aws` commands without passing additional information, you're probably correctly set up.
- Create a virtual environment and run `pip install jupyterlab && pip install -e .`
- Run `jupyter lab`. You should have a `Sync to S3` button in the file menu.

### Additional Context
- At the moment we don't have a Jupyter deployment for authoring up or an S3 bucket provisioned for this. 